### PR TITLE
fix(docker): guard for null RepoTags from `Docker.listImages()`

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -88,7 +88,7 @@ async function dockerPullLocalStack(repoTag) {
 async function isDockerLocalStackBlank() {
   let docker = new Docker()
   const allImages = await docker.listImages()
-  const images = allImages.filter(i => i.RepoTags.some(r => r.includes('localstack/localstack')))
+  const images = allImages.filter(i => i.RepoTags && i.RepoTags.some(r => r.includes('localstack/localstack')))
 
   return !images || images.length <= 0
 }


### PR DESCRIPTION
When listing docker images found on a local machine it is likely that
some of them may not have repo tags at all. Add a null guard to 
avoid a spurious exit from attempting to read non-existent tags